### PR TITLE
Add option for static/shared build, and use transient CMake compile definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@ project(librdsparser)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -pedantic")
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused -pedantic")
 
+option(RDSPARSER_BUILD_STATIC "Build a static library" OFF)
+
 option(RDSPARSER_DISABLE_HEAP "Disable heap allocator (rdsparser_new/free)" OFF)
 option(RDSPARSER_DISABLE_UNICODE "Disable unicode support" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,15 +11,9 @@ option(RDSPARSER_DISABLE_UNICODE "Disable unicode support" OFF)
 option(RDSPARSER_DISABLE_TESTS "Disable tests" OFF)
 option(RDSPARSER_DISABLE_EXAMPLES "Disable examples" OFF)
 
-if(RDSPARSER_DISABLE_HEAP)
-    add_definitions(-DRDSPARSER_DISABLE_HEAP)
-endif()
+add_subdirectory(src)
 
-if(RDSPARSER_DISABLE_UNICODE)
-    add_definitions(-DRDSPARSER_DISABLE_UNICODE)
-endif()
-
-include_directories(librdsparser PRIVATE include)
+target_include_directories(rdsparser PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 if(NOT RDSPARSER_DISABLE_TESTS)
     enable_testing()
@@ -29,5 +23,3 @@ endif()
 if(NOT RDSPARSER_DISABLE_EXAMPLES)
     add_subdirectory(examples)
 endif()
-
-add_subdirectory(src)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,5 +1,3 @@
 add_executable(rds-example main.c)
 
-target_include_directories(rds-example PRIVATE ${CMAKE_BINARY_DIR})
 target_link_libraries(rds-example rdsparser)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,11 +33,13 @@ set(SOURCE_FILES
         utils.c
         utils.h)
 
-add_library(rdsparser SHARED ${SOURCE_FILES})
-set_target_properties(rdsparser PROPERTIES PUBLIC_HEADER librdsparser.h)
-
-add_library(rdsparser_static STATIC ${SOURCE_FILES})
-set_target_properties(rdsparser_static PROPERTIES PUBLIC_HEADER librdsparser.h)
+if (RDSPARSER_BUILD_STATIC)
+    add_library(rdsparser STATIC ${SOURCE_FILES})
+    set_target_properties(rdsparser PROPERTIES PUBLIC_HEADER librdsparser.h)    
+else()
+    add_library(rdsparser SHARED ${SOURCE_FILES})
+    set_target_properties(rdsparser PROPERTIES PUBLIC_HEADER librdsparser.h)
+endif()
 
 if(RDSPARSER_DISABLE_HEAP)
     set_target_properties(rdsparser PROPERTIES PUBLIC_HEADER librdsparser_private.h)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,13 +35,14 @@ set(SOURCE_FILES
 
 if (RDSPARSER_BUILD_STATIC)
     add_library(rdsparser STATIC ${SOURCE_FILES})
-    set_target_properties(rdsparser PROPERTIES PUBLIC_HEADER librdsparser.h)    
 else()
     add_library(rdsparser SHARED ${SOURCE_FILES})
-    set_target_properties(rdsparser PROPERTIES PUBLIC_HEADER librdsparser.h)
 endif()
 
 if(RDSPARSER_DISABLE_HEAP)
-    set_target_properties(rdsparser PROPERTIES PUBLIC_HEADER librdsparser_private.h)
-    set_target_properties(rdsparser_static PROPERTIES PUBLIC_HEADER librdsparser_private.h)
+    target_compile_definitions(rdsparser PUBLIC RDSPARSER_DISABLE_HEAP)    
+endif()
+
+if(RDSPARSER_DISABLE_UNICODE)
+    target_compile_definitions(rdsparser PUBLIC RDSPARSER_DISABLE_UNICODE)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,43 +1,29 @@
-set(SOURCE_FILES
+if (RDSPARSER_BUILD_STATIC)
+    add_library(rdsparser STATIC)
+else()
+    add_library(rdsparser SHARED)
+endif()
+
+target_sources(rdsparser PRIVATE
         af.c
-        af.h
         buffer.c
-        buffer.h
         country.c
         ct.c
-        ct.h
         ecc.c
-        ecc.h
         group.c
-        group.h
         group0.c
-        group0.h
         group1.c
-        group1.h
         group2.c
-        group2.h
         group4.c
-        group4.h
         group10.c
-        group10.h
         group15.c
-        group15.h
         lps.c
-        lps.h
-        rdsparser.c
         parser.c
-        parser.h
         pty.c
+        rdsparser.c
         string.c
-        string.h
         utils.c
-        utils.h)
-
-if (RDSPARSER_BUILD_STATIC)
-    add_library(rdsparser STATIC ${SOURCE_FILES})
-else()
-    add_library(rdsparser SHARED ${SOURCE_FILES})
-endif()
+)
 
 if(RDSPARSER_DISABLE_HEAP)
     target_compile_definitions(rdsparser PUBLIC RDSPARSER_DISABLE_HEAP)    


### PR DESCRIPTION
This pull request presents the thoughts from #2.

When included as a dependency via CMake, the library now applies the desired compilation flags both to the library itself and into the dependent. In my opinion it makes the library somewhat easier to use.

The PR has not undergone the release actions so it is unclear whether the resulting binaries still operate in a similar fashion as they did before. The original actions do not seem to include header files into the zip archives so it is unclear how the release artifacts were intended to be used in, say, Linux or Windows.

The entire thing has been tested and found working as expected in https://github.com/anttikes/usb-fm-radio/tree/librdsparser and by building it manually on Linux. It has not been tested on Mac.